### PR TITLE
[RFR] Allow `null` as a valid value for translation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ module.exports = function translations(locale, isDevelopment) {
     throw new Error('The locale has to be an object.');
 
   var invalidLocale = Object.keys(locale).some(function(key) {
-    return typeof locale[key] !== 'string';
+    return typeof locale[key] !== 'string' && locale[key] !== null;
   });
 
   if (isDevelopment && invalidLocale)


### PR DESCRIPTION
There is no good reason to prevent a translation to be `null`. When deliberately wanting to define a translation to be incomplete (empty), `null` is a perfectly reasonable value.

This PR intends to fix that.

When (if?) you merge, could you please bump a new version on npm? Thanks.
